### PR TITLE
Removed outdated docstring for get_admin_url

### DIFF
--- a/django/contrib/admin/models.py
+++ b/django/contrib/admin/models.py
@@ -70,7 +70,6 @@ class LogEntry(models.Model):
     def get_admin_url(self):
         """
         Returns the admin URL to edit the object represented by this log entry.
-        This is relative to the Django admin index page.
         """
         if self.content_type and self.object_id:
             url_name = 'admin:%s_%s_change' % (self.content_type.app_label, self.content_type.model)


### PR DESCRIPTION
Since commit a4b8a4b632dbb6d9fed1a8654aed99a9c53560d4 the admin URL returned by get_admin_url() is no longer relative to the Django admin index page.